### PR TITLE
Ignore .settings folders when copying resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ task (copyResources, type: Sync) {
     from(formsSourceDir) {
         exclude '**/*.jrxml'
         exclude '**/*.jasper'
+        exclude '**/.settings/**'
     }
     into formsOutputDir
     preserve {


### PR DESCRIPTION
These files are not needed to render forms and trigger unnecessary
re-runs of the copyResources task.
